### PR TITLE
Fix missing API route

### DIFF
--- a/jiyun_portfolio/src/pages/api/server.ts
+++ b/jiyun_portfolio/src/pages/api/server.ts
@@ -1,0 +1,6 @@
+export default function handler(req, res) {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE');
+
+    res.status(200).json({ message: 'Server is running' });
+}


### PR DESCRIPTION
## Summary
- add server API route returning a basic status JSON

## Testing
- `npx jest` *(fails: 403 Forbidden while fetching jest)*

------
https://chatgpt.com/codex/tasks/task_e_6845121125d48328853803cea54379ad